### PR TITLE
fix: moduleResolution を node から bundler に変更

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,7 +13,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- `frontend/tsconfig.json` の `moduleResolution` を `node` → `bundler` に変更
- Next.js 13+ / TypeScript 5+ において `module: esnext` との組み合わせで `node` は非推奨
- `bundler` に変更することで `package.json` の `exports` フィールドが正しく解釈され、`@vis.gl/react-google-maps` などモダンなパッケージの型解決が安定する

## Test plan
- [x] `npm run build` が正常に完了すること
- [x] 地図ページ（`/map`）が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)